### PR TITLE
added admin routes for admin user 

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class AdminController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+
+    {
+        
+         $name = \Auth::user()->name;
+         $admin = \Auth::user()->admin;
+         $email = \Auth::user()->email;
+        
+
+         if ($admin == 1)$admin = "Admin";
+
+        return response()->json([
+            'message' => "Retrieved successfully",
+            'name' => $name,
+            'admin' => $admin,
+            'email' => $email], 200);
+
+
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 
+// @Aduramimo issue #127
 class AdminController extends Controller
 {
     /**
@@ -97,3 +98,4 @@ class AdminController extends Controller
         //
     }
 }
+// @Aduramimo issue #127

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -23,6 +23,9 @@ class HomeController extends Controller
      */
     public function index()
     {
+       
+       
+
         return view('home');
     }
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -63,6 +63,10 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+
+        // @Aduramimo issue #110
         'Admin' => \App\Http\Middleware\Admin::class,
+
+        // @Aduramimo issue #110
     ];
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -41,6 +41,7 @@ class Kernel extends HttpKernel
         'api' => [
             'throttle:60,1',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+
         ],
     ];
 
@@ -62,5 +63,6 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'Admin' => \App\Http\Middleware\Admin::class,
     ];
 }

--- a/app/Http/Middleware/Admin.php
+++ b/app/Http/Middleware/Admin.php
@@ -18,6 +18,6 @@ class Admin
         if (\Auth::user() &&  \Auth::user()->admin == 1) {
             return $next($request);
      }
-        return $next($request);
+        return redirect('/');
     }
 }

--- a/app/Http/Middleware/Admin.php
+++ b/app/Http/Middleware/Admin.php
@@ -13,11 +13,14 @@ class Admin
      * @param  \Closure  $next
      * @return mixed
      */
+
+    // @Aduramimo issue #110
     public function handle($request, Closure $next)
     {
         if (\Auth::user() &&  \Auth::user()->admin == 1) {
             return $next($request);
      }
         return redirect('/');
+        // @Aduramimo issue #110
     }
 }

--- a/app/Http/Middleware/Admin.php
+++ b/app/Http/Middleware/Admin.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+class Admin
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if (\Auth::user() &&  \Auth::user()->admin == 1) {
+            return $next($request);
+     }
+        return $next($request);
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -5102,27 +5102,26 @@
         },
         {
             "name": "fzaninotto/faker",
-            "version": "dev-master",
+            "version": "v1.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fzaninotto/Faker.git",
-                "reference": "5ffe7db6c80f441f150fc88008d64e64af66634b"
+                "reference": "848d8125239d7dbf8ab25cb7f054f1a630e68c2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/5ffe7db6c80f441f150fc88008d64e64af66634b",
-                "reference": "5ffe7db6c80f441f150fc88008d64e64af66634b",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/848d8125239d7dbf8ab25cb7f054f1a630e68c2e",
+                "reference": "848d8125239d7dbf8ab25cb7f054f1a630e68c2e",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0 || ^8.0"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
                 "ext-intl": "*",
                 "phpunit/phpunit": "^4.8.35 || ^5.7",
                 "squizlabs/php_codesniffer": "^2.9.2"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -5151,10 +5150,10 @@
             ],
             "support": {
                 "issues": "https://github.com/fzaninotto/Faker/issues",
-                "source": "https://github.com/fzaninotto/Faker/tree/master"
+                "source": "https://github.com/fzaninotto/Faker/tree/v1.9.2"
             },
             "abandoned": true,
-            "time": "2020-12-11T09:59:14+00:00"
+            "time": "2020-12-11T09:56:16+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -7002,5 +7001,5 @@
         "php": "^7.2.5|^8.0.3"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/database/migrations/2021_09_01_142811_create_fees_table.php
+++ b/database/migrations/2021_09_01_142811_create_fees_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFeesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('fees', function (Blueprint $table) {
+            $table->id();
+            $table->text('user');
+            $table->text('email');
+            $table->longText('payment_ref');
+            $table->longText('amount');
+            $table->date('date');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('fees');
+    }
+}

--- a/database/migrations/2021_09_02_195751_add_admin_to_users_table.php
+++ b/database/migrations/2021_09_02_195751_add_admin_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddAdminToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->integer('admin');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/database/migrations/2021_09_02_195751_add_admin_to_users_table.php
+++ b/database/migrations/2021_09_02_195751_add_admin_to_users_table.php
@@ -11,6 +11,8 @@ class AddAdminToUsersTable extends Migration
      *
      * @return void
      */
+
+    // @Aduramimo issue #129
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
@@ -30,3 +32,4 @@ class AddAdminToUsersTable extends Migration
         });
     }
 }
+// @Aduramimo issue #129

--- a/database/migrations/2021_09_02_202742_modify_the_users_table.php
+++ b/database/migrations/2021_09_02_202742_modify_the_users_table.php
@@ -11,6 +11,8 @@ class ModifyTheUsersTable extends Migration
      *
      * @return void
      */
+
+    // @Aduramimo issue #129
     public function up()
     {
       Schema::table('users', function (Blueprint $table) {
@@ -32,3 +34,4 @@ class ModifyTheUsersTable extends Migration
         });
     }
 }
+// @Aduramimo issue #129

--- a/database/migrations/2021_09_02_202742_modify_the_users_table.php
+++ b/database/migrations/2021_09_02_202742_modify_the_users_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateFeesTable extends Migration
+class ModifyTheUsersTable extends Migration
 {
     /**
      * Run the migrations.
@@ -13,13 +13,10 @@ class CreateFeesTable extends Migration
      */
     public function up()
     {
-        Schema::create('fees', function (Blueprint $table) {
-            $table->id();
-            $table->text('user');
-            $table->text('email');
-            $table->longText('payment_ref');
-            $table->longText('amount');
-            $table->date('date');
+      Schema::table('users', function (Blueprint $table) {
+            DB::statement('ALTER Table `users` ALTER `admin` SET DEFAULT 1;');
+     
+
         });
     }
 
@@ -30,6 +27,8 @@ class CreateFeesTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('fees');
+        Schema::table('users', function (Blueprint $table) {
+            //
+        });
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,3 +17,14 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:api')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+
+// routes that an admin user will have to pass through
+Route::group(['middleware' => 'Admin', 'prefix'=>'v1'], function () {
+
+    Route::get('admin', 'AdminController@index');
+    //Route::post('admin', 'AdminController@save');
+    //Route::delete('admin', 'AdminController@delete');
+    //Route::update('admin', 'AdminController@update');
+     
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,7 @@ Auth::routes();
 Route::get('/home', 'HomeController@index')->name('home');
 
 
+// @Aduramimo issue #129
 // routes that an admin user will have to pass through
 Route::group(['middleware' => 'Admin'], function () {
 
@@ -31,3 +32,4 @@ Route::group(['middleware' => 'Admin'], function () {
     //Route::update('admin', 'AdminController@update');
      
 });
+// @Aduramimo issue #129

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,3 +20,14 @@ Route::get('/', function () {
 Auth::routes();
 
 Route::get('/home', 'HomeController@index')->name('home');
+
+
+// routes that an admin user will have to pass through
+Route::group(['middleware' => 'Admin'], function () {
+
+    Route::get('admin', 'AdminController@index');
+    //Route::post('admin', 'AdminController@save');
+    //Route::delete('admin', 'AdminController@delete');
+    //Route::update('admin', 'AdminController@update');
+     
+});


### PR DESCRIPTION
1. Created Admin middleware to help check for admin users
2. Created Admin Controller to route requests for an admin logged-in user
3. Added the admin route group under web.php for all admin-based requests
4. Migrated column "admin" to the users table
5. Set the "admin" column to 1 by default, this makes a new user an admin , for us to be able to test the admin route
![image](https://user-images.githubusercontent.com/28968010/131914455-520499f1-a945-4942-b6b0-3abddf8a2bb5.png)

6. Non-admin users will be redirected home.
7. this can be tested from expenses.zuri.chat/admin
8. This is for issue #129 